### PR TITLE
Manage network toplevel attributes: renderer & version

### DIFF
--- a/netplan/config.py
+++ b/netplan/config.py
@@ -35,6 +35,14 @@ class NetPlan(object):
 
     def __init__(self, data):
         # type: (NetPlan, Dict[str, npiface.Interface]) -> None
+        self.version = 0
+        if "version" in data.keys():
+            self.version = data["version"]
+            del data["version"]
+        self.renderer = ""
+        if "renderer" in data.keys():
+            self.renderer = data["renderer"]
+            del data["renderer"]
         self.data = data
 
     def __str__(self):
@@ -66,6 +74,18 @@ class NetPlan(object):
         Provide a Python-style representation.
         """
         return "NetPlan({d})".format(d=repr(self.data))
+
+    def get_net_version(self):
+        # type: (NetPlan) -> Dict
+        if self.version != 0:
+            return {"version": self.version}
+        return {}
+
+    def get_net_renderer(self):
+        # type: (NetPlan) -> Dict
+        if self.version:
+            return {"renderer": self.renderer}
+        return {}
 
     def get_all_interfaces(self, ifaces):
         # type: (NetPlan, List[str]) -> NetPlan

--- a/netplan/interface.py
+++ b/netplan/interface.py
@@ -38,11 +38,11 @@ class Interface(object):
 
     def __str__(self):
         # type: (Interface) -> str
-        return "{sect}/{name}".format(sect=self.section, name=self.name)
+        return f"{self.section}/{self.name}"
 
     def __repr__(self):
         # type: (Interface) -> str
-        return "{cls}(name={name}, section={sect}, data={data})".format(
+        return "{cls}(name={name}, section={sect}, data={data})".format(  # pylint: disable=C0209
             cls=type(self).__name__,
             name=repr(self.name),
             sect=repr(self.section),
@@ -63,17 +63,13 @@ class Interface(object):
         """
         self.data[name] = value
 
-    def get_parent_names(self):
+    def get_parent_names(self):  # pylint: disable=R0201
         # type: (Interface) -> List[str]
         """
         Return the names of any parent interfaces that should be
         examined in addition to this one.
         """
-        raise Exception(
-            "{cls}.get_parent_names() must be overridden".format(
-                cls=type(self).__name__
-            )
-        )
+        raise Exception(f"{type(self).__name__}.get_parent_names() must be overridden")
 
 
 class PhysicalInterface(Interface):

--- a/netplan/parser.py
+++ b/netplan/parser.py
@@ -82,6 +82,8 @@ class Parser(object):
         "wifis": npiface.WirelessInterface,
     }
 
+    BY_ATTR = ["version", "renderer"]
+
     def __init__(self, dirs=NETPLAN_DIRS):
         # type: (Parser, Iterable[str]) -> None
         """
@@ -163,8 +165,7 @@ class Parser(object):
                 raise Exception(
                     "Unsupported format version {ver}".format(ver=ver)
                 )
-            del net["version"]
-            missing = sorted(set(net.keys()) - skeys)
+            missing = sorted(set(net.keys()) - skeys.union(self.BY_ATTR))
             if missing:
                 raise Exception(
                     "Unsupported section(s) {ms}".format(ms=", ".join(missing))
@@ -181,6 +182,9 @@ class Parser(object):
 
         data = {}
         for section, ifaces in raw.items():
+            if section in self.BY_ATTR:
+                data[section] = ifaces
+                continue
             cls = self.BY_SECTION[section]
             for iface, idef in ifaces.items():
                 data[iface] = cls(iface, section, idef)

--- a/netplan/parser.py
+++ b/netplan/parser.py
@@ -42,7 +42,7 @@ class ParseFileException(Exception):
         Initialize a ParseFileException object with
         the specified filename and inner exception.
         """
-        super(ParseFileException, self).__init__()
+        super().__init__()
         self.fname = fname
         self.inner = inner
 
@@ -51,18 +51,14 @@ class ParseFileException(Exception):
         """
         Provide a human-readable error message.
         """
-        return "Could not parse the {fname} netplan config file: {e}".format(
-            fname=self.fname, e=self.inner
-        )
+        return f"Could not parse the {self.fname} netplan config file: {self.inner}"
 
     def __repr__(self):
         # type: (ParseFileException) -> str
         """
         Provide a Python-style representation.
         """
-        return "ParseFileException(fname={fname}, inner={inner})".format(
-            fname=repr(self.fname), inner=repr(self.inner)
-        )
+        return f"ParseFileException(fname={repr(self.fname)}, inner={repr(self.inner)})"
 
 
 class Parser(object):
@@ -151,7 +147,7 @@ class Parser(object):
             Parse a version 2 netplan file and return a dictionary
             containing the data about the interfaces.
             """
-            with open(fname, mode="r") as infile:
+            with open(fname, mode="r", encoding="utf-8") as infile:
                 contents = yaml.safe_load(infile)
             if not isinstance(contents, dict):
                 raise Exception("The contents is not a YAML dictionary")
@@ -162,14 +158,10 @@ class Parser(object):
             if ver is None:
                 raise Exception('No "network/version" element')
             if ver != 2:
-                raise Exception(
-                    "Unsupported format version {ver}".format(ver=ver)
-                )
+                raise Exception(f"Unsupported format version {ver}")
             missing = sorted(set(net.keys()) - skeys.union(self.BY_ATTR))
             if missing:
-                raise Exception(
-                    "Unsupported section(s) {ms}".format(ms=", ".join(missing))
-                )
+                raise Exception(f'Unsupported section(s) {", ".join(missing)}')
             return cast(Dict[str, Any], net)
 
         raw = {}  # type: Dict[str, Any]
@@ -178,7 +170,7 @@ class Parser(object):
             try:
                 self._combine_dicts(raw, parse_file(fname))
             except Exception as exc:
-                raise ParseFileException(fname=fname, inner=exc)
+                raise ParseFileException(fname=fname, inner=exc) from exc
 
         data = {}
         for section, ifaces in raw.items():

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ RE_VERSION = r"""^
 
 def get_version():
     # type: () -> str
-    """ Get the version string from the module's __init__ file. """
+    """Get the version string from the module's __init__ file."""
     found = None
     re_semver = re.compile(RE_VERSION, re.X)
     with open("netplan/config.py") as init:

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,15 @@
 [tox]
-envlist = pep8,mypy_2,mypy_3,unit_tests_2,unit_tests_3,pylint,black
+envlist = pep8,mypy_3,unit_tests_3,pylint,black
 skipsdist = True
-
-[testenv:mypy_2]
-basepython = python3
-deps = mypy
-commands =
-  mypy --disallow-untyped-defs --disallow-untyped-calls --py2 netplan
-  mypy --disallow-untyped-defs --disallow-untyped-calls --ignore-missing-imports --py2 unit_tests
 
 [testenv:mypy_3]
 basepython = python3
-deps = mypy
+deps =
+  mypy
+  types-PyYAML
 commands =
   mypy --strict netplan
   mypy --strict --ignore-missing-imports --allow-untyped-decorators unit_tests
-
-[testenv:unit_tests_2]
-basepython = python2
-deps =
-  ddt
-  pytest
-  PyYAML
-  typing
-commands = pytest -s -vv {posargs}
 
 [testenv:unit_tests_3]
 basepython = python3
@@ -37,7 +23,7 @@ commands = pytest -s -vv {posargs}
 basepython = python3
 deps = flake8
 commands =
-  flake8 {posargs} bin/netplan-parser netplan unit_tests
+  flake8 --max-line-length=100 {posargs} bin/netplan-parser netplan unit_tests
 
 [testenv:pylint]
 basepython = python3
@@ -53,10 +39,10 @@ commands =
 basepython = python3
 deps =
   black
-commands = black --check --line-length 79 setup.py netplan unit_tests
+commands = black --check --line-length 100 setup.py netplan unit_tests
 
 [testenv:black_reformat]
 basepython = python3
 deps =
   black
-commands = black --line-length 79 setup.py netplan unit_tests
+commands = black --line-length 100 setup.py netplan unit_tests

--- a/unit_tests/test_interface.py
+++ b/unit_tests/test_interface.py
@@ -60,7 +60,7 @@ class TestInterfaces(unittest.TestCase):
         assert str(obj) == "section/iface"
         got = repr(obj)
         exp = (
-            "{name}(name='iface', section='section', "
+            "{name}(name='iface', section='section', "  # pylint: disable=C0209
             "data={{'mtu': 1500}})".format(name=cls.__name__)
         )
         assert got == exp
@@ -104,7 +104,5 @@ class TestInterfaces(unittest.TestCase):
         """
         Test querying an interface for its parent.
         """
-        obj = cls(
-            "iface", "section", {"interfaces": ["i1", "i2"], "link": "lnk"}
-        )
+        obj = cls("iface", "section", {"interfaces": ["i1", "i2"], "link": "lnk"})
         assert obj.get_parent_names() == parents

--- a/unit_tests/test_parser.py
+++ b/unit_tests/test_parser.py
@@ -44,11 +44,7 @@ class TestParserCombine(unittest.TestCase):
         ({"a": 1, "b": "c"}, {"a": 2}, {"a": 2, "b": "c"}),
         ({"a": [1]}, {}, {"a": [1]}),
         ({"a": [1]}, {"a": [2]}, {"a": [1, 2]}),
-        (
-            {"a": {"b": ["c"]}},
-            {"a": {"b": [0], "e": 17}},
-            {"a": {"b": ["c", 0], "e": 17}},
-        ),
+        ({"a": {"b": ["c"]}}, {"a": {"b": [0], "e": 17}}, {"a": {"b": ["c", 0], "e": 17}}),
         (
             {"a": 1, "b": {"c": [2], "d": "3"}},
             {"a": 42, "b": {"c": [4], "e": 5}, "f": 6.0},
@@ -185,10 +181,7 @@ class TestParser(unittest.TestCase):
         _combine_dict() and "exclude" should work together to
         parse some real-life data files.
         """
-        dirs = [
-            "test_data/{sub}/{d}/netplan".format(sub=subdir, d=d)
-            for d in ("lib", "etc", "run")
-        ]
+        dirs = [f"test_data/{subdir}/{d}/netplan" for d in ("lib", "etc", "run")]
         parser = npparser.Parser(dirs=dirs)
         if exclude is None:
             data = parser.parse()
@@ -200,18 +193,8 @@ class TestParser(unittest.TestCase):
     @ddt.data(
         ("override", ["eno1"], "ethernets: eno1", "ethernets: eno1"),
         ("full-9000", ["eno1"], "ethernets: eno1", "ethernets: eno1"),
-        (
-            "full-9000",
-            ["enp2s0.617"],
-            "ethernets: enp2s0; vlans: enp2s0.617",
-            "ethernets: enp2s0",
-        ),
-        (
-            "full-9000",
-            ["br-enp4s0"],
-            "bridges: br-enp4s0; ethernets: enp4s0",
-            "ethernets: enp4s0",
-        ),
+        ("full-9000", ["enp2s0.617"], "ethernets: enp2s0; vlans: enp2s0.617", "ethernets: enp2s0"),
+        ("full-9000", ["br-enp4s0"], "bridges: br-enp4s0; ethernets: enp4s0", "ethernets: enp4s0"),
         (
             "full-9000",
             ["br-enp4s0", "enp2s0.617"],
@@ -231,10 +214,7 @@ class TestParser(unittest.TestCase):
         get_all_interfaces() should return all the related interfaces, and
         get_physical_interfaces() should only return physical interfaces.
         """
-        dirs = [
-            "test_data/{sub}/{d}/netplan".format(sub=subdir, d=d)
-            for d in ("lib", "etc", "run")
-        ]
+        dirs = [f"test_data/{subdir}/{d}/netplan" for d in ("lib", "etc", "run")]
         parser = npparser.Parser(dirs=dirs)
         data = parser.parse()
         assert set(ifaces).issubset(set(data.data.keys()))


### PR DESCRIPTION
To be able to re-generate a config from an existing manage and store network attributes `renderer` and `version`
Fix linters issues
Remove python2 from tox